### PR TITLE
Added `NoqtaEditor` component

### DIFF
--- a/src/components/NoqtaEditor.tsx
+++ b/src/components/NoqtaEditor.tsx
@@ -1,0 +1,13 @@
+import { EditorContent, useEditor } from "@tiptap/react";
+import StarterKit from "@tiptap/starter-kit";
+
+function NoqtaEditor() {
+	const editor = useEditor({
+		extensions: [StarterKit],
+		content: "<p>Hello World!</p>",
+	});
+
+	return <EditorContent editor={editor} />;
+}
+
+export { NoqtaEditor };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,1 @@
+export { NoqtaEditor } from "./components/NoqtaEditor";

--- a/src/tests/components/NoqtaEditor.test.tsx
+++ b/src/tests/components/NoqtaEditor.test.tsx
@@ -1,0 +1,12 @@
+import { NoqtaEditor } from "../../../src";
+import { render, screen } from "@testing-library/react";
+
+describe("NoqtaEditor", () => {
+	it("renders without crashing", () => {
+		render(<NoqtaEditor />);
+		const editor = screen.getByRole("textbox");
+		expect(editor).toBeInTheDocument();
+		expect(editor).toHaveAttribute("contenteditable", "true");
+		expect(editor).toHaveClass("ProseMirror");
+	});
+});


### PR DESCRIPTION
This pull request adds a bare-bones editor component, `NoqtaEditor`, built using the TipTap library. The changes include the implementation of the component, its export for use in other parts of the application, and a corresponding unit test to ensure proper functionality.

### The `NoqtaEditor` component:
* `src/components/NoqtaEditor.tsx`: Added a new `NoqtaEditor` component built with TipTap's `useEditor` hook and `StarterKit` extension. The editor initializes with default content and renders an editable area.

### Exporting the component:
* `src/index.ts`: Exported the `NoqtaEditor` component to make it available for use across the application.

### Unit testing:
* `src/tests/components/NoqtaEditor.test.tsx`: Added a test suite for the `NoqtaEditor` component to verify it renders correctly, has the expected attributes, and includes the `ProseMirror` class.