### PR TITLE
added `initialContent` prop for the `NoqtaEditor`

### DIFF
--- a/src/components/NoqtaEditor.tsx
+++ b/src/components/NoqtaEditor.tsx
@@ -1,10 +1,10 @@
 import { EditorContent, useEditor } from "@tiptap/react";
 import StarterKit from "@tiptap/starter-kit";
 
-function NoqtaEditor() {
+function NoqtaEditor({ initialContent }: { initialContent?: string }) {
 	const editor = useEditor({
 		extensions: [StarterKit],
-		content: "<p>Hello World!</p>",
+		content: initialContent || "<p>Hello World!</p>",
 	});
 
 	return <EditorContent editor={editor} />;

--- a/src/tests/components/NoqtaEditor.test.tsx
+++ b/src/tests/components/NoqtaEditor.test.tsx
@@ -9,4 +9,11 @@ describe("NoqtaEditor", () => {
 		expect(editor).toHaveAttribute("contenteditable", "true");
 		expect(editor).toHaveClass("ProseMirror");
 	});
+
+	it("renders with initial content", () => {
+		const initialContent = "<p>Initial content</p>";
+		render(<NoqtaEditor initialContent={initialContent} />);
+		const editor = screen.getByRole("textbox");
+		expect(editor).toHaveTextContent("Initial content");
+	});
 });


### PR DESCRIPTION
This pull request updates the `NoqtaEditor` component to support customizable initial content and adds a corresponding test to ensure this functionality works as expected.

### Enhancements to `NoqtaEditor`:

* Updated the `NoqtaEditor` component to accept an optional `initialContent` prop, which allows users to specify the initial content of the editor. If no content is provided, it defaults to `<p>Hello World!</p>`. `src/components/NoqtaEditor.tsx`

### Testing improvements:

* Added a new test case to verify that the `NoqtaEditor` component correctly renders the provided `initialContent`. `src/tests/components/NoqtaEditor.test.tsx`