### PR TITLE
added `extensions` prop to the `NoqtaEditor` component

### DIFF
--- a/src/components/NoqtaEditor.tsx
+++ b/src/components/NoqtaEditor.tsx
@@ -1,9 +1,16 @@
+import { Extension } from "@tiptap/core";
 import { EditorContent, useEditor } from "@tiptap/react";
 import StarterKit from "@tiptap/starter-kit";
 
-function NoqtaEditor({ initialContent }: { initialContent?: string }) {
+function NoqtaEditor({
+	initialContent,
+	extensions,
+}: {
+	initialContent?: string;
+	extensions?: Extension[];
+}) {
 	const editor = useEditor({
-		extensions: [StarterKit],
+		extensions: [StarterKit, ...(extensions || [])],
 		content: initialContent || "<p>Hello World!</p>",
 	});
 

--- a/src/tests/components/NoqtaEditor.test.tsx
+++ b/src/tests/components/NoqtaEditor.test.tsx
@@ -1,3 +1,4 @@
+import { Extension } from "@tiptap/core";
 import { NoqtaEditor } from "../../../src";
 import { render, screen } from "@testing-library/react";
 
@@ -15,5 +16,29 @@ describe("NoqtaEditor", () => {
 		render(<NoqtaEditor initialContent={initialContent} />);
 		const editor = screen.getByRole("textbox");
 		expect(editor).toHaveTextContent("Initial content");
+	});
+
+	it("applies custom extensions", () => {
+		const customExtension = Extension.create({
+			name: "customExtension",
+			addGlobalAttributes() {
+				return [
+					{
+						types: ["paragraph"],
+						attributes: {
+							style: {
+								default: "color: red;",
+							},
+						},
+					},
+				];
+			},
+		});
+
+		render(<NoqtaEditor initialContent="<p>Hello World!!</p>" extensions={[customExtension]} />);
+		const paragraph = screen.getByText("Hello World!!");
+		expect(paragraph).toBeInTheDocument();
+		expect(paragraph.tagName).toBe("P");
+		expect(paragraph).toHaveAttribute("style", "color: red;");
 	});
 });


### PR DESCRIPTION
This pull request updates the `NoqtaEditor` component to support custom extensions and adds a corresponding test to validate this functionality. The changes improve the flexibility and test coverage of the editor component.

### Enhancements to `NoqtaEditor` functionality:
* `src/components/NoqtaEditor.tsx` Updated the `NoqtaEditor` component to accept an optional `extensions` prop, allowing users to provide custom TipTap extensions. The `extensions` are merged with the default `StarterKit` extensions.

### Test updates for `NoqtaEditor`:
* `src/tests/components/NoqtaEditor.test.tsx`: Added a new test case to verify that custom extensions are applied correctly. The test uses a custom extension to add a red text color style to paragraph elements and confirms that the style is applied as expected.