### PR TITLE
added `defaultExtensions` prop to the `NoqtaEditor` component

### DIFF
--- a/src/components/NoqtaEditor.tsx
+++ b/src/components/NoqtaEditor.tsx
@@ -1,15 +1,28 @@
+import { useMemo } from "react";
 import { EditorContent, useEditor } from "@tiptap/react";
-import StarterKit from "@tiptap/starter-kit";
 
 import type { NoqtaEditorProps } from "../types/components";
+
+import createDefaultExtensions from "../extensions/default";
 
 /**
  * NoqtaEditor is a React component that provides a rich text editor using [Tiptap](https://tiptap.dev/).
  */
 function NoqtaEditor(props: NoqtaEditorProps) {
+	// Use the default extensions based on the provided configuration
+	const defaultExtensions = useMemo(
+		() => createDefaultExtensions(props.defaultExtensionsConfig),
+		[props.defaultExtensionsConfig]
+	);
+
+	// Combine default extensions with any additional extensions provided via props
+	const extensions = useMemo(() => {
+		return props.extensions ? [...defaultExtensions, ...props.extensions] : defaultExtensions;
+	}, [defaultExtensions, props.extensions]);
+
 	const editor = useEditor({
-		extensions: [StarterKit, ...(props.extensions || [])],
-		content: props.initialContent || "<p>Hello World!</p>",
+		extensions: extensions,
+		content: props.initialContent || "Start typing...",
 	});
 
 	return <EditorContent editor={editor} />;

--- a/src/extensions/default.ts
+++ b/src/extensions/default.ts
@@ -1,0 +1,148 @@
+/*
+ * Default extensions for the rich text editor.
+ * This file exports a function that creates an array of Tiptap extensions
+ * based on the provided configuration options.
+ *
+ * Inspired by the Tiptap Starter Kit
+ */
+
+import { Blockquote } from "@tiptap/extension-blockquote";
+import { Bold } from "@tiptap/extension-bold";
+import { Italic } from "@tiptap/extension-italic";
+import { BulletList } from "@tiptap/extension-bullet-list";
+import { Code } from "@tiptap/extension-code";
+import { Document } from "@tiptap/extension-document";
+import { Dropcursor } from "@tiptap/extension-dropcursor";
+import { Gapcursor } from "@tiptap/extension-gapcursor";
+import { HardBreak } from "@tiptap/extension-hard-break";
+import { Heading } from "@tiptap/extension-heading";
+import { History } from "@tiptap/extension-history";
+import { HorizontalRule } from "@tiptap/extension-horizontal-rule";
+import { ListItem } from "@tiptap/extension-list-item";
+import { OrderedList } from "@tiptap/extension-ordered-list";
+import { Paragraph } from "@tiptap/extension-paragraph";
+import { Strike } from "@tiptap/extension-strike";
+import { Text } from "@tiptap/extension-text";
+import { TaskList, TaskItem } from "@tiptap/extension-list";
+import { TextStyle, Color } from "@tiptap/extension-text-style";
+import { Underline } from "@tiptap/extension-underline";
+import { TrailingNode } from "@tiptap/extensions";
+
+import Link from "@tiptap/extension-link";
+import Image from "@tiptap/extension-image";
+import Highlight from "@tiptap/extension-highlight";
+
+import type { DefaultExtensions } from "../types/extensions";
+
+/**
+ * Creates an array of default Tiptap extensions based on the provided configuration options.
+ * @param {DefaultExtensions} options - Configuration options or false to disable specific extensions.
+ * @returns {Array} An array of Tiptap extensions.
+ */
+const createDefaultExtensions = (
+	options: DefaultExtensions = {
+		blockquote: {},
+		bold: {},
+		bulletList: {},
+		code: {},
+		dropcursor: {},
+		gapcursor: true,
+		hardBreak: {},
+		heading: {},
+		history: {},
+		horizontalRule: {},
+		italic: {},
+		listItem: {},
+		orderedList: {},
+		strike: {},
+		underline: {},
+		highlight: {
+			multicolor: true,
+		},
+		image: {
+			inline: true,
+			allowBase64: true,
+		},
+		color: {},
+		link: {
+			openOnClick: true,
+		},
+		taskList: {},
+	}
+): Array<any> => {
+	const extensions = [];
+
+	if (options.blockquote !== false) {
+		extensions.push(Blockquote.configure(options.blockquote));
+	}
+	if (options.bold !== false) {
+		extensions.push(Bold.configure(options.bold));
+	}
+	if (options.bulletList !== false) {
+		extensions.push(BulletList.configure(options.bulletList));
+	}
+	if (options.code !== false) {
+		extensions.push(Code.configure(options.code));
+	}
+	if (options.dropcursor !== false) {
+		extensions.push(Dropcursor.configure(options.dropcursor));
+	}
+	if (options.gapcursor !== false) {
+		extensions.push(Gapcursor);
+	}
+	if (options.hardBreak !== false) {
+		extensions.push(HardBreak.configure(options.hardBreak));
+	}
+	if (options.heading !== false) {
+		extensions.push(Heading.configure(options.heading));
+	}
+	if (options.history !== false) {
+		extensions.push(History.configure(options.history));
+	}
+	if (options.horizontalRule !== false) {
+		extensions.push(HorizontalRule.configure(options.horizontalRule));
+	}
+	if (options.italic !== false) {
+		extensions.push(Italic.configure(options.italic));
+	}
+	if (options.listItem !== false) {
+		extensions.push(ListItem.configure(options.listItem));
+	}
+	if (options.orderedList !== false) {
+		extensions.push(OrderedList.configure(options.orderedList));
+	}
+	if (options.strike !== false) {
+		extensions.push(Strike.configure(options.strike));
+	}
+	if (options.underline !== false) {
+		extensions.push(Underline.configure(options.underline));
+	}
+	if (options.highlight !== false) {
+		extensions.push(Highlight.configure(options.highlight));
+	}
+	if (options.color !== false) {
+		extensions.push(Color.configure(options.color), TextStyle);
+	}
+	if (options.taskList !== false) {
+		extensions.push(TaskList.configure(options.taskList), TaskItem);
+	}
+	if (options.image !== false) {
+		extensions.push(Image.configure(options.image));
+	}
+	if (options.link !== false) {
+		extensions.push(Link.configure(options.link));
+	}
+
+	extensions.push(
+		TrailingNode.configure({
+			node: "paragraph",
+		})
+	);
+	extensions.push(Paragraph);
+	extensions.push(Document);
+	extensions.push(Text);
+
+	return extensions;
+};
+
+export default createDefaultExtensions;

--- a/src/tests/components/NoqtaEditor.test.tsx
+++ b/src/tests/components/NoqtaEditor.test.tsx
@@ -41,4 +41,73 @@ describe("NoqtaEditor", () => {
 		expect(paragraph.tagName).toBe("P");
 		expect(paragraph).toHaveAttribute("style", "color: red;");
 	});
+
+	it("renders with default extensions", () => {
+		const testContent = `
+        <h1> Heading 1</h1>
+        <h2> Heading 2</h2>
+        <strong>Bold text</strong>
+        <em>Italic text</em>
+        <del>Strikethrough text</del>
+        <code>code</code>
+        `;
+
+		render(<NoqtaEditor initialContent={testContent} />);
+		const editor = screen.getByRole("textbox");
+		expect(editor).toBeInTheDocument();
+
+		const headings = screen.getAllByRole("heading");
+		expect(headings).toHaveLength(2);
+		expect(headings[0]).toHaveTextContent("Heading 1");
+		expect(headings[1]).toHaveTextContent("Heading 2");
+
+		const boldText = screen.getByRole("strong");
+		expect(boldText).toHaveTextContent("Bold text");
+
+		const italicText = screen.getByRole("emphasis");
+		expect(italicText).toHaveTextContent("Italic text");
+
+		const strikethroughText = screen.getByText("Strikethrough text");
+		expect(strikethroughText.tagName).toBe("S");
+
+		const codeText = screen.getByRole("code");
+		expect(codeText).toHaveTextContent("code");
+	});
+
+	it("renders without excluded extensions", () => {
+		const testContent = `
+        <h1> Heading 1</h1>
+        <h2> Heading 2</h2>
+        <strong>Bold text</strong>
+        <em>Italic text</em>
+        <del>Strikethrough text</del>
+        <code>code</code>
+        `;
+
+		render(
+			<NoqtaEditor
+				initialContent={testContent}
+				defaultExtensionsConfig={{
+					italic: false,
+					bold: false,
+				}}
+			/>
+		);
+		const editor = screen.getByRole("textbox");
+		expect(editor).toBeInTheDocument();
+
+		const headings = screen.getAllByRole("heading");
+		expect(headings).toHaveLength(2);
+		expect(headings[0]).toHaveTextContent("Heading 1");
+		expect(headings[1]).toHaveTextContent("Heading 2");
+
+		expect(screen.queryByRole("strong")).not.toBeInTheDocument();
+		expect(screen.queryByRole("emphasis")).not.toBeInTheDocument();
+
+		const strikethroughText = screen.getByText("Strikethrough text");
+		expect(strikethroughText.tagName).toBe("S");
+
+		const codeText = screen.getByRole("code");
+		expect(codeText).toHaveTextContent("code");
+	});
 });

--- a/src/tests/extensions/default.test.ts
+++ b/src/tests/extensions/default.test.ts
@@ -1,0 +1,43 @@
+import { expect } from "vitest";
+import createDefaultExtensions from "../../extensions/default";
+
+describe("createDefaultExtensions", () => {
+	it("should return an array of extensions", () => {
+		const extensions = createDefaultExtensions();
+		expect(extensions).toBeInstanceOf(Array);
+	});
+
+	it("should include specific extensions by default", () => {
+		const extensions = createDefaultExtensions();
+		const extensionNames = extensions.map((ext) => ext.name);
+		expect(extensionNames).toContain("bold");
+		expect(extensionNames).toContain("italic");
+		expect(extensionNames).toContain("paragraph");
+		expect(extensionNames).toContain("heading");
+	});
+
+	it("should allow configuration of extensions", () => {
+		const customConfig = {
+			bold: { HTMLAttributes: { class: "custom-bold" } },
+			italic: { HTMLAttributes: { class: "custom-italic" } },
+		};
+		const extensions = createDefaultExtensions(customConfig);
+		const boldExtension = extensions.find((ext) => ext.name === "bold");
+		const italicExtension = extensions.find((ext) => ext.name === "italic");
+
+		expect(boldExtension?.options.HTMLAttributes.class).toBe("custom-bold");
+		expect(italicExtension?.options.HTMLAttributes.class).toBe("custom-italic");
+	});
+
+	it("should handle false options to disable extensions", () => {
+		const extensions = createDefaultExtensions({
+			bold: false,
+			italic: false,
+		});
+		const extensionNames = extensions.map((ext) => ext.name);
+		expect(extensionNames).not.toContain("bold");
+		expect(extensionNames).not.toContain("italic");
+		expect(extensionNames).toContain("paragraph");
+		expect(extensionNames).toContain("heading");
+	});
+});

--- a/src/types/components.ts
+++ b/src/types/components.ts
@@ -1,6 +1,8 @@
 import type { Extension } from "@tiptap/core";
+import type { DefaultExtensions } from "./extensions";
 
 export interface NoqtaEditorProps {
 	initialContent?: string;
 	extensions?: Extension[];
+	defaultExtensionsConfig?: DefaultExtensions;
 }

--- a/src/types/extensions.ts
+++ b/src/types/extensions.ts
@@ -1,0 +1,42 @@
+import type { BlockquoteOptions } from "@tiptap/extension-blockquote";
+import type { BoldOptions } from "@tiptap/extension-bold";
+import type { BulletListOptions } from "@tiptap/extension-bullet-list";
+import type { CodeOptions } from "@tiptap/extension-code";
+import type { DropcursorOptions } from "@tiptap/extension-dropcursor";
+import type { HardBreakOptions } from "@tiptap/extension-hard-break";
+import type { HeadingOptions } from "@tiptap/extension-heading";
+import type { HistoryOptions } from "@tiptap/extension-history";
+import type { HorizontalRuleOptions } from "@tiptap/extension-horizontal-rule";
+import type { ItalicOptions } from "@tiptap/extension-italic";
+import type { ListItemOptions } from "@tiptap/extension-list-item";
+import type { OrderedListOptions } from "@tiptap/extension-ordered-list";
+import type { StrikeOptions } from "@tiptap/extension-strike";
+import type { LinkOptions } from "@tiptap/extension-link";
+import type { TaskListOptions } from "@tiptap/extension-list";
+import type { HighlightOptions } from "@tiptap/extension-highlight";
+import type { ColorOptions } from "@tiptap/extension-text-style";
+import type { UnderlineOptions } from "@tiptap/extension-underline";
+import type { ImageOptions } from "@tiptap/extension-image";
+
+export interface DefaultExtensions {
+	blockquote?: Partial<BlockquoteOptions> | false;
+	bold?: Partial<BoldOptions> | false;
+	bulletList?: Partial<BulletListOptions> | false;
+	code?: Partial<CodeOptions> | false;
+	dropcursor?: Partial<DropcursorOptions> | false;
+	gapcursor?: boolean;
+	hardBreak?: Partial<HardBreakOptions> | false;
+	heading?: Partial<HeadingOptions> | false;
+	history?: Partial<HistoryOptions> | false;
+	horizontalRule?: Partial<HorizontalRuleOptions> | false;
+	italic?: Partial<ItalicOptions> | false;
+	listItem?: Partial<ListItemOptions> | false;
+	orderedList?: Partial<OrderedListOptions> | false;
+	strike?: Partial<StrikeOptions> | false;
+	underline?: Partial<UnderlineOptions> | false;
+	highlight?: Partial<HighlightOptions> | false;
+	color?: Partial<ColorOptions> | false;
+	link?: Partial<LinkOptions> | false;
+	taskList?: Partial<TaskListOptions> | false;
+	image?: Partial<ImageOptions> | false;
+}


### PR DESCRIPTION
This pull request introduces significant enhancements to the `NoqtaEditor` component, focusing on modularity, configurability, and test coverage. The most notable changes include refactoring the editor to support customizable default extensions, creating a dedicated utility for managing these extensions, and adding comprehensive type definitions and tests.

### Refactoring and modularization:

* Refactored the `NoqtaEditor` component to use a new `createDefaultExtensions` utility for managing default Tiptap extensions. This allows merging default extensions with user-provided extensions and adds support for configuration via props.

* Introduced a new utility function, `createDefaultExtensions`, to generate a customizable array of Tiptap extensions based on provided configuration options. This modularizes extension management and improves reusability.

### Type definitions:

* Added a `NoqtaEditorProps` interface to define the props for the `NoqtaEditor` component, including support for `initialContent`, custom extensions, and configurable default extensions.

* Defined a `DefaultExtensions` interface to specify configuration options for each Tiptap extension, allowing fine-grained control over which extensions are enabled and how they are configured.

### Test coverage:

* Added tests for the `NoqtaEditor` component to verify rendering with default extensions, handling of excluded extensions, and proper integration with the new configuration system.

* Added unit tests for the `createDefaultExtensions` utility to ensure it correctly generates extensions, handles configuration options, and disables extensions when specified.