### PR TITLE
Added Rich text support for links

### DIFF
--- a/src/extensions/default.ts
+++ b/src/extensions/default.ts
@@ -27,8 +27,8 @@ import { TaskList, TaskItem } from "@tiptap/extension-list";
 import { TextStyle, Color } from "@tiptap/extension-text-style";
 import { Underline } from "@tiptap/extension-underline";
 import { TrailingNode } from "@tiptap/extensions";
+import { RichTextLink } from "./rich-text-links";
 
-import Link from "@tiptap/extension-link";
 import Image from "@tiptap/extension-image";
 import Highlight from "@tiptap/extension-highlight";
 import CustomTable from "./extended-tables";
@@ -138,7 +138,7 @@ const createDefaultExtensions = (
 		extensions.push(Image.configure(options.image));
 	}
 	if (options.link !== false) {
-		extensions.push(Link.configure(options.link));
+		extensions.push(RichTextLink.configure(options.link));
 	}
 	if (options.table !== false) {
 		extensions.push(CustomTable.configure(options.table), TableCell, TableRow, TableHeader);

--- a/src/extensions/rich-text-links.ts
+++ b/src/extensions/rich-text-links.ts
@@ -1,0 +1,121 @@
+/*
+ * Custom extension that extends the built-in `Link` extension to add additional input/paste rules
+ * for converting the Markdown link syntax (i.e. `[Doist](https://doist.com)`) into links.
+ *
+ * credit: https://github.com/Doist/typist/blob/main/src/extensions/rich-text/rich-text-link.ts
+ */
+
+import { InputRule, markInputRule, markPasteRule, PasteRule } from "@tiptap/core";
+import { Link } from "@tiptap/extension-link";
+
+import { type RichTextLinkOptions } from "../types/extensions";
+
+/**
+ * The input regex for Markdown links with title support, and multiple quotation marks (required
+ * in case the `Typography` extension is being included).
+ */
+const inputRegex = /(?:^|\s)\[([^\]]*)?\]\((\S+)(?: ["“](.+)["”])?\)$/i;
+
+/**
+ * The paste regex for Markdown links with title support, and multiple quotation marks (required
+ * in case the `Typography` extension is being included).
+ */
+const pasteRegex = /(?:^|\s)\[([^\]]*)?\]\((\S+)(?: ["“](.+)["”])?\)/gi;
+
+/**
+ * Input rule built specifically for the `Link` extension, which ignores the auto-linked URL in
+ * parentheses (e.g., `(https://doist.dev)`).
+ *
+ * @see https://github.com/ueberdosis/tiptap/discussions/1865
+ */
+function linkInputRule(config: Parameters<typeof markInputRule>[0]) {
+	const defaultMarkInputRule = markInputRule(config);
+
+	return new InputRule({
+		find: config.find,
+		handler(props) {
+			const { tr } = props.state;
+
+			defaultMarkInputRule.handler(props);
+			tr.setMeta("preventAutolink", true);
+		},
+	});
+}
+
+/**
+ * Paste rule built specifically for the `Link` extension, which ignores the auto-linked URL in
+ * parentheses (e.g., `(https://doist.dev)`). This extension was inspired from the multiple
+ * implementations found in a Tiptap discussion at GitHub.
+ *
+ * @see https://github.com/ueberdosis/tiptap/discussions/1865
+ */
+function linkPasteRule(config: Parameters<typeof markPasteRule>[0]) {
+	const defaultMarkPasteRule = markPasteRule(config);
+
+	return new PasteRule({
+		find: config.find,
+		handler(props) {
+			const { tr } = props.state;
+
+			defaultMarkPasteRule.handler(props);
+			tr.setMeta("preventAutolink", true);
+		},
+	});
+}
+
+/**
+ * Custom extension that extends the built-in `Link` extension to add additional input/paste rules
+ * for converting the Markdown link syntax (i.e. `[Doist](https://doist.com)`) into links, and also
+ * adds support for the `title` attribute.
+ */
+const RichTextLink = Link.extend<RichTextLinkOptions>({
+	inclusive: false,
+	addAttributes() {
+		return {
+			...this.parent?.(),
+			title: {
+				default: null,
+			},
+		};
+	},
+	addInputRules() {
+		return [
+			linkInputRule({
+				find: inputRegex,
+				type: this.type,
+
+				// We need to use `pop()` to remove the last capture groups from the match to
+				// satisfy Tiptap's `markPasteRule` expectation of having the content as the last
+				// capture group in the match (this makes the attribute order important)
+				getAttributes(match) {
+					return {
+						title: match.pop()?.trim(),
+						href: match.pop()?.trim(),
+					};
+				},
+			}),
+		];
+	},
+	addPasteRules() {
+		return [
+			linkPasteRule({
+				find: pasteRegex,
+				type: this.type,
+
+				// We need to use `pop()` to remove the last capture groups from the match to
+				// satisfy Tiptap's `markInputRule` expectation of having the content as the last
+				// capture group in the match (this makes the attribute order important)
+				getAttributes(match) {
+					return {
+						title: match.pop()?.trim(),
+						href: match.pop()?.trim(),
+					};
+				},
+			}),
+		];
+	},
+});
+
+export { RichTextLink };
+
+export type { RichTextLinkOptions };

--- a/src/types/extensions.ts
+++ b/src/types/extensions.ts
@@ -43,3 +43,8 @@ export interface DefaultExtensions {
 	table?: Partial<TableOptions> | false;
 	codeBlockLowlight?: boolean;
 }
+
+/**
+ * The options available to customize the `RichTextLink` extension.
+ */
+export type RichTextLinkOptions = LinkOptions;


### PR DESCRIPTION
This pull request introduces a custom `RichTextLink` extension for handling Markdown-style links with enhanced functionality, replacing the default `Link` extension in the Tiptap editor setup. The most important changes include the addition of the `RichTextLink` extension, updates to the default extensions configuration, and the introduction of new types to support the custom extension.

### Introduction of `RichTextLink` extension:
* Added a new file `src/extensions/rich-text-links.ts` that defines the `RichTextLink` extension. This extension extends the default `Link` extension to support Markdown link syntax (e.g., `[Doist](https://doist.com)`), adds support for the `title` attribute, and includes custom input and paste rules to handle links more effectively.

### Integration into default extensions:
* Updated `src/extensions/default.ts` to replace the default `Link` extension with the newly created `RichTextLink` extension in the `createDefaultExtensions` function.
* Updated imports in `src/extensions/default.ts` to include `RichTextLink` and remove the default `Link` extension import.

### Type definitions:
* Added a new `RichTextLinkOptions` type in `src/types/extensions.ts` to define the configuration options for the `RichTextLink` extension.