### PR TITLE
feat(extensions): added ability to add an image from toolbar

### DIFF
--- a/src/components/NoqtaEditor.tsx
+++ b/src/components/NoqtaEditor.tsx
@@ -26,7 +26,6 @@ function NoqtaEditor(props: NoqtaEditorProps) {
 		() => createDefaultExtensions(props.defaultExtensionsConfig),
 		[props.defaultExtensionsConfig]
 	);
-	defaultExtensions.forEach((ext) => ext.name === "textAlign" && console.log(ext.name));
 
 	// Combine default extensions with any additional extensions provided via props
 	const extensions = useMemo(() => {

--- a/src/components/ToolsMenuComponent.tsx
+++ b/src/components/ToolsMenuComponent.tsx
@@ -1,22 +1,16 @@
 import { Editor } from "@tiptap/core";
 import "../styles/components/ToolsMenuComponent.css";
 import FontFormatingTools from "./editor-tools/FontFormatingTools";
-import { useEffect, useState } from "react";
 import ContentFormatingTools from "./editor-tools/ContentFormatingTools";
 import FontStylingTools from "./editor-tools/FontStylingTools";
+import Button from "./ui-elements/Button";
+import { BiImageAdd } from "react-icons/bi";
+import useForceRerender from "../hooks/ForceRerender";
 
 function ToolsMenuComponent({ editor }: { editor: Editor }) {
-	const [, setTick] = useState(0); // to force rerender on selection change
-	useEffect(() => {
-		if (!editor) return;
-		const onSel = () => setTick((t) => t + 1); // small state just to force rerender
-		editor.on("selectionUpdate", onSel);
-		editor.on("update", onSel);
-		return () => {
-			editor.off("selectionUpdate", onSel);
-			editor.off("update", onSel);
-		};
-	}, [editor]);
+	// Force rerender on editor updates to reflect changes in button states
+	useForceRerender(editor);
+
 	return (
 		<div id="tools-menu">
 			<FontFormatingTools editor={editor} />
@@ -24,6 +18,28 @@ function ToolsMenuComponent({ editor }: { editor: Editor }) {
 			<ContentFormatingTools editor={editor} />
 			<span className="separator"></span>
 			<FontStylingTools editor={editor} />
+			<span className="separator"></span>
+			<Button
+				title="Add Image"
+				onClick={() => {
+					const url = window.prompt("Image URL");
+					if (url) {
+						editor
+							.chain()
+							.focus()
+							.setImage({
+								src: url,
+								alt: "Image",
+								title: "Image",
+							})
+							.run();
+					}
+				}}
+				disabled={
+					editor.isActive("codeBlock") || editor.isActive("customTable") || editor.isActive("image")
+				}>
+				<BiImageAdd />
+			</Button>
 		</div>
 	);
 }

--- a/src/components/extensions-components/CustomTableComponent.tsx
+++ b/src/components/extensions-components/CustomTableComponent.tsx
@@ -15,6 +15,7 @@ import { TbTableColumn, TbTableRow } from "react-icons/tb";
 import type { CustomTableComponentProps } from "../../types/components";
 import HorizontalCenter from "../layout-components/HorizontalCenter";
 import "../../styles/components/CustomTableComponent.css";
+import useForceRerender from "../../hooks/ForceRerender";
 
 /**
  * CustomTableComponent is a React component that renders a table with various controls
@@ -22,6 +23,9 @@ import "../../styles/components/CustomTableComponent.css";
  * merging cells, and toggling header rows and columns.
  */
 function CustomTableComponent(props: CustomTableComponentProps) {
+	// Force rerender on editor updates to reflect changes in table controls
+	useForceRerender(props.editor);
+
 	const controls = useMemo(() => {
 		return {
 			addRowAfter: {
@@ -86,19 +90,21 @@ function CustomTableComponent(props: CustomTableComponentProps) {
 					</colgroup>
 				}
 			</NodeViewContent>
-			<HorizontalCenter className="table-controls">
-				{Object.values(controls).map((control) => (
-					<Button
-						key={control.label}
-						title={control.label}
-						children={control.icon}
-						onClick={control.action}
-						style={{
-							margin: "0.25rem 0",
-						}}
-					/>
-				))}
-			</HorizontalCenter>
+			{props.editor.isActive("customTable") && (
+				<HorizontalCenter className="table-controls">
+					{Object.values(controls).map((control) => (
+						<Button
+							key={control.label}
+							title={control.label}
+							children={control.icon}
+							onClick={control.action}
+							style={{
+								margin: "0.25rem 0",
+							}}
+						/>
+					))}
+				</HorizontalCenter>
+			)}
 		</NodeViewWrapper>
 	);
 }

--- a/src/extensions/default.ts
+++ b/src/extensions/default.ts
@@ -101,7 +101,12 @@ const createDefaultExtensions = (
 		extensions.push(HardBreak.configure(options.hardBreak));
 	}
 	if (options.heading !== false) {
-		extensions.push(Heading.configure(options.heading));
+		extensions.push(
+			Heading.configure({
+				...options.heading,
+				HTMLAttributes: SmartTyping.options.showSymbols ? { "data-symbol": "#" } : {},
+			})
+		);
 	}
 	if (options.history !== false) {
 		extensions.push(History.configure(options.history));
@@ -146,7 +151,14 @@ const createDefaultExtensions = (
 		extensions.push(TaskList.configure(options.taskList), TaskItem);
 	}
 	if (options.image !== false) {
-		extensions.push(Image.configure({ inline: true, allowBase64: true, ...options.image }));
+		extensions.push(
+			Image.configure({
+				inline: true,
+				allowBase64: true,
+				...options.image,
+				HTMLAttributes: { addedImg: "noqta-added-img", textAlign: "center" },
+			})
+		);
 	}
 	if (options.link !== false) {
 		extensions.push(
@@ -177,7 +189,7 @@ const createDefaultExtensions = (
 	if (options.textAlign !== false) {
 		extensions.push(
 			TextAlign.configure({
-				types: ["heading", "paragraph", "blockquote", "listItem", "taskItem"],
+				types: ["heading", "paragraph", "blockquote", "listItem", "taskItem", "image"],
 				defaultAlignment: "left",
 				...options.textAlign,
 			})

--- a/src/hooks/ForceRerender.tsx
+++ b/src/hooks/ForceRerender.tsx
@@ -1,0 +1,18 @@
+import type { Editor } from "@tiptap/core";
+import { useEffect, useState } from "react";
+
+function useForceRerender(editor: Editor) {
+	const [, setTick] = useState(0); // to force rerender on selection change
+	useEffect(() => {
+		if (!editor) return;
+		const onSel = () => setTick((t) => t + 1); // small state just to force rerender
+		editor.on("selectionUpdate", onSel);
+		editor.on("update", onSel);
+		return () => {
+			editor.off("selectionUpdate", onSel);
+			editor.off("update", onSel);
+		};
+	}, [editor]);
+}
+
+export default useForceRerender;

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -43,3 +43,14 @@
 #editor-container input[type="color"]::-webkit-color-swatch {
 	border: none;
 }
+
+#editor-container p:has(> img[addedImg="noqta-added-img"]) {
+	display: flex;
+	justify-content: center;
+}
+
+#editor-container img[addedImg="noqta-added-img"] {
+	width: 50%;
+	aspect-ratio: 2 / 1;
+	border-radius: 1rem;
+}

--- a/src/styles/markdown.css
+++ b/src/styles/markdown.css
@@ -32,31 +32,31 @@
 	font-size: 1em;
 }
 
-#editor-container h1::before,
-#editor-container h2::before,
-#editor-container h3::before,
-#editor-container h4::before,
-#editor-container h5::before,
-#editor-container h6::before {
+#editor-container h1[data-symbol]::before,
+#editor-container h2[data-symbol]::before,
+#editor-container h3[data-symbol]::before,
+#editor-container h4[data-symbol]::before,
+#editor-container h5[data-symbol]::before,
+#editor-container h6[data-symbol]::before {
 	opacity: 0.5;
 }
 
-#editor-container h1::before {
+#editor-container h1[data-symbol]::before {
 	content: "# ";
 }
-#editor-container h2::before {
+#editor-container h2[data-symbol]::before {
 	content: "## ";
 }
-#editor-container h3::before {
+#editor-container h3[data-symbol]::before {
 	content: "### ";
 }
-#editor-container h4::before {
+#editor-container h4[data-symbol]::before {
 	content: "#### ";
 }
-#editor-container h5::before {
+#editor-container h5[data-symbol]::before {
 	content: "##### ";
 }
-#editor-container h6::before {
+#editor-container h6[data-symbol]::before {
 	content: "###### ";
 }
 


### PR DESCRIPTION
- Adjusted the styling of image elements
- Created a hook to force rerender
- Added logic to display the controls of the table element if table is current active element
- Added ability to control whether to show heading symbols `#` before heading elements